### PR TITLE
Updates to support new virtual servers

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -87,7 +87,7 @@ def version(project=None):
     require('user', 'hosts', 'webroot',
         used_for='These variables are used for finding the target deployment environment.',
     )
-    with cd(os.path.join(env.build_path, env.project, 'build')):
+    with cd(os.path.join(env.build_path, env.project)):
         run('git show | head -10')
 
 def reload_apache():
@@ -128,7 +128,7 @@ def deploy(project=None, commit=None):
     )
 
     make_path = time.strftime('ding-%Y%m%d%H%M')[:-1]
-    cwd = os.path.join(env.build_path, env.project, 'build')
+    cwd = os.path.join(env.build_path, env.project)
     abs_make_path = os.path.join(cwd, make_path)
 
     with cd(cwd):

--- a/fabfile.py
+++ b/fabfile.py
@@ -92,8 +92,8 @@ def sync_from_prod(project=None):
         abort('sync_from_prod is not supported for non-stg roles.')
 
     run('mysqldump drupal6_ding_%s_prod | mysql drupal6_ding_%s_stg' % (env.project, env.project))
-    prodPath = env.webroot_pattern % {'project': project, 'role': 'prod'}
-    stgPath = env.webroot_pattern % {'project': project, 'role': 'stg'}
+    prodPath = env.webroot_pattern % {'project': env.project, 'role': 'prod'}
+    stgPath = env.webroot_pattern % {'project': env.project, 'role': 'stg'}
     run('sudo rsync -avmCF --delete %(prod)s %(stg)s' % {
         'prod': os.path.join(prodPath, 'files'),
         'stg': os.path.join(stgPath, 'files')


### PR DESCRIPTION
Added support for project/host based files directory. Most/all new virtual servers use the default sites/default/files directory.

Also removed sudo from rsync. The deploy user on these servers do not have sudo rights and based on my tests in does not seem to be needed.

I'm not a python expert so your comments are welcome, @cableman, @mikl.
