### PR TITLE
Use NanoSOAP 1.0-beta3

### DIFF
--- a/ding.make
+++ b/ding.make
@@ -136,7 +136,7 @@ projects[menu_block][subdir] = "contrib"
 projects[menu_block][version] = "2.4"
 
 projects[nanosoap][subdir] = contrib
-projects[nanosoap][version] = 1.x-dev
+projects[nanosoap][version] = "1.0-beta3"
 
 projects[oembed][subdir] = "contrib"
 projects[oembed][version] = "0.8"


### PR DESCRIPTION
This fix ensures that special characters in requests e.g. & are escaped properly.

This fixes #1804 as a part of release 1.7.0.
