### PR TITLE
Fixed up mobile handling in Varnish.

### DIFF
--- a/conf/ding-2.1.x.vcl
+++ b/conf/ding-2.1.x.vcl
@@ -171,7 +171,7 @@ sub vcl_recv {
   if (req.http.Cookie) {
     set req.http.Cookie = ";" req.http.Cookie;
     set req.http.Cookie = regsuball(req.http.Cookie, "; +", ";");
-    set req.http.Cookie = regsuball(req.http.Cookie, ";(SESS[a-z0-9]+|NO_CACHE)=", "; \1=");
+    set req.http.Cookie = regsuball(req.http.Cookie, ";(SESS[a-z0-9]+|NO_CACHE|mt_device)=", "; \1=");
     set req.http.Cookie = regsuball(req.http.Cookie, ";[^ ][^;]*", "");
     set req.http.Cookie = regsuball(req.http.Cookie, "^[; ]+|[; ]+$", "");
 

--- a/conf/ding-2.1.x.vcl
+++ b/conf/ding-2.1.x.vcl
@@ -102,7 +102,13 @@ sub vcl_recv {
     if (req.http.user-agent ~ "Mobile") {
       set req.http.user-agent = "Mobile";
     } else {
-      set req.http.user-agent = "iPad";
+      # Opera Mobile is an odd case, it adds Tablet to the string on tablets
+      # (that's caught above), but not "Mobile" normally.
+      if (req.http.user-agent ~ "Opera Mobi") {
+        set req.http.user-agent = "Mobile";
+      } else {
+        set req.http.user-agent = "iPad";
+      }
     }
   } else if (req.http.user-agent ~ "(?i)ipod|iphone|opera mini|opera mobi|blackberry|up.browser|up.link|mmp|symbian|smartphone|midp|wap|vodafone|o2|pocket|kindle|mobile|pda|psp|treo") {
     # "opera mobi" isn't a typo, Opera Mobile calls itself that.


### PR DESCRIPTION
This fixes caching of mobile clients, making the redirect option of mobile_tools work.

Uses 3 bins: Mobile for phones, iPad for tablets (including Android and Windows tablets) and Desktop for the rest.

See [ticket #1899](https://libraryding.lighthouseapp.com/projects/27862-hovedspor/tickets/1899).
