### PR TITLE
Remove trampoline

### DIFF
--- a/ding.make
+++ b/ding.make
@@ -278,11 +278,6 @@ projects[ting][download][type] = "git"
 projects[ting][download][url] = "https://github.com/dingproject/ting.git"
 projects[ting][download][revision] = "v1.8.0"
 
-projects[trampoline][type] = "module"
-projects[trampoline][download][type] = "git"
-projects[trampoline][download][url] = "https://github.com/dingproject/trampoline.git"
-projects[trampoline][download][revision] = "v1.3.1"
-
 projects[webtrends][type] = "module"
 projects[webtrends][download][type] = "git"
 projects[webtrends][download][url] = "https://github.com/dingproject/webtrends.git"


### PR DESCRIPTION
The module is incompatible with later versions of Drupal and thus disabled on many Ding sites. We should consider removing it entirely.

If we want to keep the performance boost that trampoline should provide we should consider migrating the implementations to http://drupal.org/project/js.

This pull request is not considered complete. We need update hooks to disable the module and remove any hook_trampoline implementations as well.
